### PR TITLE
[기능 구현] 책 읽기 진행사항 실시간 반영

### DIFF
--- a/lib/book_detail_page.dart
+++ b/lib/book_detail_page.dart
@@ -6,6 +6,8 @@ import 'package:phopes/models/book_chapters.dart';
 import 'package:phopes/models/book_record.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 import 'package:isar/isar.dart';
+import 'package:phopes/provider/reading_progress_provider.dart';
+import 'package:provider/provider.dart';
 import 'models/book.dart';
 
 class BookDetailPage extends StatefulWidget {
@@ -33,7 +35,6 @@ class _BookDetailPage extends State<BookDetailPage> {
 
   @override
   void initState() {
-    // TODO: 준형 Provider로 상태관리
     super.initState();
     book = isar.books.filter().idEqualTo(widget.bookId).findFirst();
     bookChapters = isar.bookChapters
@@ -65,10 +66,23 @@ class _BookDetailPage extends State<BookDetailPage> {
       chapter = chapter.value!.next;
       chaptersOrder.add(chapter.value!.id);
     }
+    changeProgress();
+  }
+
+  changeProgress() async {
+    ReadingProgressProvider _readingProgressProvider =
+        Provider.of(context, listen: false);
+    await _readingProgressProvider.refresReadingProgress(widget.bookId);
   }
 
   @override
   Widget build(BuildContext context) {
+    int finishedChaptersCount =
+        Provider.of<ReadingProgressProvider>(context).getInt;
+
+    List finishedChaptersIds =
+        Provider.of<ReadingProgressProvider>(context).getList;
+
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: Scaffold(

--- a/lib/book_view_page.dart
+++ b/lib/book_view_page.dart
@@ -3,6 +3,8 @@ import 'package:phopes/isar_services.dart';
 import 'package:phopes/models/book_chapter.dart';
 import 'package:phopes/models/book_record.dart';
 import 'package:phopes/models/daily_record.dart';
+import 'package:phopes/provider/reading_progress_provider.dart';
+import 'package:provider/provider.dart';
 import 'models/book.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 import 'package:isar/isar.dart';
@@ -301,6 +303,11 @@ class _BookViewPageState extends State<BookViewPage> {
                                     await bookRecord.currentChapter.save();
                                   });
                                 }
+                                final myState =
+                                    Provider.of<ReadingProgressProvider>(
+                                        context,
+                                        listen: false);
+                                myState.refresReadingProgress(widget.bookId);
                               } else {
                                 showDialog(
                                   context: context,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:phopes/isar_services.dart';
+import 'package:phopes/provider/reading_progress_provider.dart';
+import 'package:provider/provider.dart';
 import '/study_plan_page.dart';
 import 'student_home_page.dart';
 import 'first_page.dart';
@@ -15,7 +17,9 @@ import 'thanks_for_donation.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  await Firebase.initializeApp(
+      name: "phopes", options: DefaultFirebaseOptions.currentPlatform);
+
   IsarService();
   runApp(const MyApp());
 }
@@ -25,26 +29,34 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: "login",
-      theme: ThemeData(primarySwatch: Colors.blue),
-      initialRoute: '/first',
-      routes: {
-        '/first': (context) => FirstPage(),
-        '/main': (context) => const StudentHomePage(),
-        '/study_plan': (context) => const StudyPlanPage(),
-        '/update': (context) => const UpdatePage(),
-        '/check_before_donation': (context) => const CheckBeforeDonation(),
-        '/input_phone_info': (context) => const InputPhoneInfo(),
-        '/check_phone_info': (context) => CheckPhoneInfo(
-              cellPhoneMem: '',
-              cellPhoneType: '',
-              serialNumber: '',
-            ),
-        '/finish_phone_donation': (context) => const FinishPhoneDontaion(),
-        '/checklist_before_start': (context) => const CheckListBeforeStart(),
-        '/thanks_for_donation': (context) => const ThanksForDonation(),
-      },
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => ReadingProgressProvider(),
+        )
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        title: "login",
+        theme: ThemeData(primarySwatch: Colors.blue),
+        initialRoute: '/first',
+        routes: {
+          '/first': (context) => FirstPage(),
+          '/main': (context) => const StudentHomePage(),
+          '/study_plan': (context) => const StudyPlanPage(),
+          '/update': (context) => const UpdatePage(),
+          '/check_before_donation': (context) => const CheckBeforeDonation(),
+          '/input_phone_info': (context) => const InputPhoneInfo(),
+          '/check_phone_info': (context) => CheckPhoneInfo(
+                cellPhoneMem: '',
+                cellPhoneType: '',
+                serialNumber: '',
+              ),
+          '/finish_phone_donation': (context) => const FinishPhoneDontaion(),
+          '/checklist_before_start': (context) => const CheckListBeforeStart(),
+          '/thanks_for_donation': (context) => const ThanksForDonation(),
+        },
+      ),
     );
   }
 }

--- a/lib/provider/reading_progress_provider.dart
+++ b/lib/provider/reading_progress_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:isar/isar.dart';
+import 'package:phopes/models/book.dart';
+import 'package:phopes/models/book_record.dart';
+import '../isar_services.dart';
+
+class ReadingProgressProvider with ChangeNotifier {
+  Isar isar = IsarService().db!;
+  late List _finishedChapters = [];
+  late List _finishedChaptersIds = [];
+
+  // getter method
+  int get getInt => _finishedChapters.length;
+  List get getList => _finishedChaptersIds;
+
+  Future<void> refresReadingProgress(int id) async {
+    List<dynamic> finishedChapters = await isar.bookRecords
+        .filter()
+        .book((q) => q.idEqualTo(id))
+        .findFirstSync()!
+        .readChapters
+        .toList();
+    for (var element in finishedChapters) {
+      _finishedChaptersIds.add(element.id);
+    }
+    _finishedChapters = finishedChapters;
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
navigator pop을 통해 책 읽기 사항이 실시간으로 관리가 안되었던 부분을 provider를 통해 설정했습니다.  책 챕터 뷰 화면에서 읽음 버튼을 누르고 뒤로가기를 클릭하면 곧 이어 나오는 책 챕터 목록 화면(이전화면)에 책 진행도와 읽은 챕터 리스트에 해당 챕터가 바로 반영 되게 끔 세팅하였습니다.