### PR TITLE
코드 로그인 / 유저 여행 + 휴대폰 정보 등록 반영

### DIFF
--- a/lib/check_before_donation.dart
+++ b/lib/check_before_donation.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'input_phone_info.dart';
+import 'package:uuid/uuid.dart';
 
 class CheckBeforeDonation extends StatefulWidget {
-  const CheckBeforeDonation({
+  String city;
+  String period;
+  CheckBeforeDonation({
+    required this.city,
+    required this.period,
     super.key,
   });
 
@@ -274,7 +279,8 @@ class _CheckBeforeDonation extends State<CheckBeforeDonation> {
                         ),
                         onPressed: () {
                           Navigator.of(context).push(MaterialPageRoute(
-                              builder: (context) => const InputPhoneInfo()));
+                              builder: (context) => InputPhoneInfo(
+                                  city: widget.city, period: widget.period)));
                         },
                         shape: const RoundedRectangleBorder(
                           borderRadius:

--- a/lib/check_phone_info.dart
+++ b/lib/check_phone_info.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
 import 'finish_phone_donation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:uuid/uuid.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:phopes/widgets/trip_register_card.dart';
 
 class CheckPhoneInfo extends StatefulWidget {
+  String city;
+  String period;
   String cellPhoneType;
   String cellPhoneMem;
   String serialNumber;
-
+  FirebaseFirestore db = FirebaseFirestore.instance;
+  FirebaseAuth auth = FirebaseAuth.instance;
   CheckPhoneInfo({
+    required this.city,
+    required this.period,
     required this.cellPhoneMem,
     required this.cellPhoneType,
     required this.serialNumber,
@@ -231,9 +240,27 @@ class _CheckPhoneInfo extends State<CheckPhoneInfo> {
                           ),
                         ),
                         onPressed: () {
+                          var randomCode = Uuid().v4();
+                          /*firestore에 phone 정보 넣기 */
+                          final data = <String, String>{
+                            "phoneModel": widget.cellPhoneType,
+                            "memory": widget.cellPhoneMem,
+                            "IMEI": widget.serialNumber,
+                            "authcode": randomCode
+                          };
+                          widget.db
+                              .collection("users")
+                              .doc(widget.auth.currentUser!.email!)
+                              .collection("travels")
+                              .doc("travel - " + widget.city)
+                              .collection("phone")
+                              .doc("phone - " + widget.city)
+                              .set(data)
+                              .onError((e, _) =>
+                                  print("Error writing document: $e"));
                           Navigator.of(context).push(MaterialPageRoute(
                               builder: (context) =>
-                                  const FinishPhoneDontaion()));
+                                  FinishPhoneDontaion(authcode: randomCode)));
                         },
                         shape: const RoundedRectangleBorder(
                           borderRadius:

--- a/lib/code_login_page.dart
+++ b/lib/code_login_page.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'id_login_page.dart';
 import 'student_home_page.dart';
@@ -13,6 +14,7 @@ class CodeLoginPage extends StatefulWidget {
 class _CodeLoginPage extends State<CodeLoginPage>
     with SingleTickerProviderStateMixin {
   TextEditingController? _codeTextController;
+  FirebaseFirestore db = FirebaseFirestore.instance;
 
   @override
   void initState() {
@@ -63,9 +65,31 @@ class _CodeLoginPage extends State<CodeLoginPage>
             MaterialButton(
                 minWidth: 340,
                 height: 50,
-                onPressed: () {
-                  Navigator.of(context).push(MaterialPageRoute(
-                      builder: (context) => StudentHomePage()));
+                onPressed: () async {
+                  DocumentSnapshot studentInfo = await db
+                      .collection("students")
+                      .doc(_codeTextController!.text)
+                      .get();
+                  print(studentInfo);
+                  if (!studentInfo.exists) {
+                    showDialog(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return AlertDialog(
+                              content: Text("Check your code"),
+                              actions: [
+                                MaterialButton(
+                                  child: Text("confirm"),
+                                  onPressed: () {
+                                    Navigator.of(context).pop();
+                                  },
+                                )
+                              ]);
+                        });
+                  } else {
+                    Navigator.of(context).push(MaterialPageRoute(
+                        builder: (context) => StudentHomePage()));
+                  }
                 },
                 color: Colors.blueAccent,
                 child: const Text(

--- a/lib/finish_phone_donation.dart
+++ b/lib/finish_phone_donation.dart
@@ -1,18 +1,18 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'user_home_page.dart';
 
 class FinishPhoneDontaion extends StatefulWidget {
-  const FinishPhoneDontaion({
+  String authcode;
+  FinishPhoneDontaion({
+    required this.authcode,
     super.key,
   });
-
   @override
   State<FinishPhoneDontaion> createState() => _FinishPhoneDontaion();
 }
 
 class _FinishPhoneDontaion extends State<FinishPhoneDontaion> {
-  String phopesCode = 'PHOPES1234';
-
   @override
   void initState() {
     super.initState();
@@ -20,6 +20,8 @@ class _FinishPhoneDontaion extends State<FinishPhoneDontaion> {
 
   @override
   Widget build(BuildContext context) {
+    String phoneCode = widget.authcode.substring(24);
+    FirebaseFirestore db = FirebaseFirestore.instance;
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: Scaffold(
@@ -111,7 +113,7 @@ class _FinishPhoneDontaion extends State<FinishPhoneDontaion> {
                                 text: TextSpan(
                                   children: [
                                     TextSpan(
-                                      text: 'Unlock-Phone Code : $phopesCode',
+                                      text: 'Unlock-Phone Code : ' + phoneCode,
                                       style: const TextStyle(
                                         color: Color(0xff999999),
                                         fontSize: 28 / 2,
@@ -167,6 +169,11 @@ class _FinishPhoneDontaion extends State<FinishPhoneDontaion> {
                           ),
                         ),
                         onPressed: () {
+                          final data = <String, String>{
+                            /*student에 필요한 데이터*/
+                          };
+                          /*phoneCode firebase - student collection에 넣기 */
+                          db.collection("students").doc(phoneCode).set(data);
                           Navigator.of(context).push(MaterialPageRoute(
                               builder: (context) => UserHomePage(
                                   selectedCity: "", selectedPeriod: "")));

--- a/lib/input_phone_info.dart
+++ b/lib/input_phone_info.dart
@@ -2,7 +2,11 @@ import 'package:flutter/material.dart';
 import 'check_phone_info.dart';
 
 class InputPhoneInfo extends StatefulWidget {
-  const InputPhoneInfo({
+  String city;
+  String period;
+  InputPhoneInfo({
+    required this.city,
+    required this.period,
     super.key,
   });
 
@@ -434,6 +438,8 @@ class _InputPhoneInfo extends State<InputPhoneInfo> {
                               } else {
                                 Navigator.of(context).push(MaterialPageRoute(
                                     builder: (context) => CheckPhoneInfo(
+                                          city: widget.city,
+                                          period: widget.period,
                                           cellPhoneType: cellPhoneType,
                                           cellPhoneMem: cellPhoneMem,
                                           serialNumber: serialNumber,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,14 +49,21 @@ class MyApp extends StatelessWidget {
           '/main': (context) => const StudentHomePage(),
           '/study_plan': (context) => const StudyPlanPage(),
           '/update': (context) => const UpdatePage(),
-          '/check_before_donation': (context) => const CheckBeforeDonation(),
-          '/input_phone_info': (context) => const InputPhoneInfo(),
+          '/check_before_donation': (context) => CheckBeforeDonation(
+                city: "",
+                period: "",
+              ),
+          '/input_phone_info': (context) =>
+              InputPhoneInfo(city: "", period: ""),
           '/check_phone_info': (context) => CheckPhoneInfo(
+                city: "",
+                period: "",
                 cellPhoneMem: '',
                 cellPhoneType: '',
                 serialNumber: '',
               ),
-          '/finish_phone_donation': (context) => const FinishPhoneDontaion(),
+          '/finish_phone_donation': (context) =>
+              FinishPhoneDontaion(authcode: ""),
           '/checklist_before_start': (context) => const CheckListBeforeStart(),
           '/thanks_for_donation': (context) => const ThanksForDonation(),
         },

--- a/lib/widgets/trip_register_card.dart
+++ b/lib/widgets/trip_register_card.dart
@@ -1,13 +1,23 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:phopes/select_region_page.dart';
 import 'package:phopes/select_date_page.dart';
 import 'package:phopes/check_before_donation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:uuid/uuid.dart';
 
 class TripRegisterCard extends StatelessWidget {
   String city;
   String period;
   TripRegisterCard({super.key, required this.city, required this.period});
+  FirebaseFirestore db = FirebaseFirestore.instance;
+  // Future getCurrentUser() async{
+  //   FirebaseUser _user;
+  //   _user = await FirebaseAuth.instance.currentUser()
 
+  // }
+  FirebaseAuth auth = FirebaseAuth.instance;
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -75,8 +85,23 @@ class TripRegisterCard extends StatelessWidget {
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8)),
                 onPressed: () {
+                  var travelId = Uuid().v4();
+                  final data = <String, String>{
+                    "destination": city,
+                    "period": period,
+                    "owner": auth.currentUser!.displayName!,
+                    "pid": travelId
+                  };
+                  db
+                      .collection("users")
+                      .doc(auth.currentUser!.email!)
+                      .collection("travels")
+                      .doc("travel - " + city)
+                      .set(data)
+                      .onError((e, _) => print("Error writing document: $e"));
                   Navigator.of(context).push(MaterialPageRoute(
-                      builder: (context) => const CheckBeforeDonation()));
+                      builder: (context) =>
+                          CheckBeforeDonation(city: city, period: period)));
                 },
                 color: Colors.blueAccent,
                 child: const Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -636,10 +636,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.14"
   material_color_utilities:
     dependency: transitive
     description:
@@ -652,10 +652,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   mime:
     dependency: transitive
     description:
@@ -1049,10 +1049,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.4.18"
   time:
     dependency: transitive
     description:
@@ -1142,7 +1142,7 @@ packages:
     source: hosted
     version: "3.0.5"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
@@ -1214,5 +1214,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   isar_flutter_libs: ^3.0.5
   table_calendar: ^3.0.0
   google_sign_in: ^6.1.0
+  uuid: ^3.0.7
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
[코드 수정]
1. trip_register_card.dart 수정 : 여행 도시와 기간이 로그인한 유저의 travel collection에 들어가도록

2. code_login.dart 수정 : 텍스트 필드에 입력하는 code가 firebase상에 등록된 authcode여야 로그인 가능

3. main.dart / input_phone_info.dart / check_phone_info.dart / finish_phone_donation.dart / check_before_donation.dart 수정 :
travel register 정보(도시와 여행기간) 이 상속되어 finish_phone_donation 페이지의 버튼을 눌렀을 때 로그인한 유저의 travel 정보에 phone정보들이 들어갈 수 있도록

 [firestore DB 수정]
1. users 컬렉션 추가
 - email(필드)
 - joinedAt(필드)
 - username(필드)
 - travel(컬렉션) : 유저가 등록한 travel들을 담는 컬렉션

2. users(컬렉션) -> travel(컬렉션)
 - phone(컬렉션)
 - destination(필드)
 - period(필드)
 - pid(필드) : 고유 ID

3. users(컬렉션) -> travel(컬렉션) -> phone(컬렉션)
 - IMEI(필드)
 - authcode(필드) : 고유 ID로써 이 정보로 학생 로그인 코드를 생성
 - memory(필드) 
 - phoneModel(필드)